### PR TITLE
 ✨🐛 Add update method, fix main file path in package.json

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,5 +1,5 @@
 
-const { MatchHeight } = require('../lib');
+const { MatchHeight } = require('../src');
 
 const el1 = new MatchHeight('div.block');
 const el2 = new MatchHeight('ul li');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-match-height",
   "version": "1.0.7",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "repository": "https://github.com/PeteyRev/js-match-height",
   "scripts": {
     "build": "cross-env BABEL_ENV=production babel src --out-dir lib",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,12 @@ The timeout for the debounce method is defaulted at 250. You can set your time i
 const matchHeight = new MatchHeight('ul.list-items  li', { timeout:400 });
 ```
 
+You can manually trigger a height recalculation with the update method. This is useful if the DOM itself changes without a window resize. 
+
+```
+matchHeight.update();
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE) file for details

--- a/src/index.js
+++ b/src/index.js
@@ -38,4 +38,8 @@ export class MatchHeight {
       if (callNow) func.apply(context, args);
     };
   }
+
+  update() {
+    this.getAndSet(this.$elsArray);
+  }
 }


### PR DESCRIPTION
You can use `matchHeight.update()` to manually trigger a recalculation. This is useful for when the DOM changes but the screen does not resize. 